### PR TITLE
fix: empty screen after pressing any key

### DIFF
--- a/src/View.zig
+++ b/src/View.zig
@@ -186,10 +186,6 @@ pub fn drawCurrentPage(self: *Self, win: vaxis.Window) !void {
         );
         defer img.deinit();
 
-        if (self.current_page) |old_img| {
-            self.vx.freeImage(self.tty.anyWriter(), old_img.id);
-        }
-
         const new_image = try self.vx.transmitImage(
             self.allocator,
             self.tty.anyWriter(),


### PR DESCRIPTION
Just updated to latest commit and found out the first screen loads ok, but as soon as I press any button, the image disappears.