### PR TITLE
Enable `headerpad_max_install_names` to fix Mach-O relocation for Homebrew bottles

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -35,6 +35,8 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
+    exe.headerpad_max_install_names = true;
+
     const deps = .{
         .vaxis = b.dependency("vaxis", .{ .target = target, .optimize = optimize }),
         .fzwatch = b.dependency("fzwatch", .{ .target = target, .optimize = optimize }),


### PR DESCRIPTION
similar to https://github.com/ziglang/zig/issues/13388

verified via https://github.com/chenrui333/homebrew-tap/pull/8