### PR TITLE
Go to page, vim style

### DIFF
--- a/src/PdfHandler.zig
+++ b/src/PdfHandler.zig
@@ -199,6 +199,14 @@ pub fn changePage(self: *Self, delta: i32) bool {
     return false;
 }
 
+pub fn goToPage(self: *Self, pageNum: i32) bool {
+    if (pageNum >= 0 and pageNum <= self.total_pages) {
+        self.current_page_number = @as(u16, @intCast(pageNum));
+        return true;
+    }
+    return false;
+}
+
 pub fn adjustZoom(self: *Self, increase: bool) void {
     const factor = self.size * config.General.zoom_step / 2;
     if (increase) {

--- a/src/View.zig
+++ b/src/View.zig
@@ -25,6 +25,8 @@ current_page: ?vaxis.Image,
 watcher: ?fzwatch.Watcher,
 thread: ?std.Thread,
 reload: bool,
+is_changing_page: bool,
+change_page_num: i32,
 
 pub fn init(allocator: std.mem.Allocator, args: [][]const u8) !Self {
     const path = args[1];
@@ -54,6 +56,8 @@ pub fn init(allocator: std.mem.Allocator, args: [][]const u8) !Self {
         .mouse = null,
         .thread = null,
         .reload = false,
+        .is_changing_page = false,
+        .change_page_num = 0,
     };
 }
 
@@ -154,6 +158,25 @@ fn handleKeyStroke(self: *Self, key: vaxis.Key) !void {
         self.pdf_handler.scroll(.Left);
     } else if (key.matches(km.scroll_right.key, km.scroll_right.modifiers)) {
         self.pdf_handler.scroll(.Right);
+    } else if (key.matches(km.go_to_page.key, km.go_to_page.modifiers) and !self.is_changing_page) {
+        self.is_changing_page = true;
+    } else if (key.codepoint >= 48 and key.codepoint <= 57) {
+        const num: i32 = key.codepoint - 48;
+        if (self.change_page_num == 0) {
+            self.change_page_num = num;
+        } else {
+            self.change_page_num = (self.change_page_num * 10) + num;
+        }
+    } else if (key.matches(km.go_to_page.key, km.go_to_page.modifiers) and self.is_changing_page) {
+        self.is_changing_page = false;
+        const change_to = self.change_page_num - 1;
+        self.change_page_num = 0;
+        if (change_to >= 0) {
+            if (self.pdf_handler.goToPage(change_to)) {
+                self.resetCurrentPage();
+                self.pdf_handler.resetZoomAndScroll();
+            }
+        }
     }
 
     self.reload = true;

--- a/src/View.zig
+++ b/src/View.zig
@@ -158,16 +158,23 @@ fn handleKeyStroke(self: *Self, key: vaxis.Key) !void {
         self.pdf_handler.scroll(.Left);
     } else if (key.matches(km.scroll_right.key, km.scroll_right.modifiers)) {
         self.pdf_handler.scroll(.Right);
-    } else if (key.matches(km.go_to_page.key, km.go_to_page.modifiers) and !self.is_changing_page) {
+
+        // enable change page mode
+    } else if (key.matches(km.go_to_page.key, km.go_to_page.modifiers)) {
         self.is_changing_page = true;
-    } else if (key.codepoint >= 48 and key.codepoint <= 57) {
+        self.change_page_num = 0;
+
+        // add up number presses
+    } else if (key.codepoint >= 48 and key.codepoint <= 57 and self.is_changing_page) {
         const num: i32 = key.codepoint - 48;
         if (self.change_page_num == 0) {
             self.change_page_num = num;
         } else {
             self.change_page_num = (self.change_page_num * 10) + num;
         }
-    } else if (key.matches(km.go_to_page.key, km.go_to_page.modifiers) and self.is_changing_page) {
+
+        // switch to the page
+    } else if (key.matches(km.enter.key, km.enter.modifiers) and self.is_changing_page) {
         self.is_changing_page = false;
         const change_to = self.change_page_num - 1;
         self.change_page_num = 0;

--- a/src/config.zig
+++ b/src/config.zig
@@ -8,7 +8,8 @@ pub const KeyMap = struct {
     pub const scroll_right = .{ .key = 'l', .modifiers = .{} };
     pub const zoom_in = .{ .key = 'i', .modifiers = .{} };
     pub const zoom_out = .{ .key = 'o', .modifiers = .{} };
-    pub const go_to_page = .{ .key = 'g', .modifiers = .{} };
+    pub const go_to_page = .{ .key = ':', .modifiers = .{} };
+    pub const enter = .{ .key = '\r', .modifiers = .{} };
     pub const quit = .{ .key = 'c', .modifiers = .{ .ctrl = true } };
 };
 

--- a/src/config.zig
+++ b/src/config.zig
@@ -8,6 +8,7 @@ pub const KeyMap = struct {
     pub const scroll_right = .{ .key = 'l', .modifiers = .{} };
     pub const zoom_in = .{ .key = 'i', .modifiers = .{} };
     pub const zoom_out = .{ .key = 'o', .modifiers = .{} };
+    // to jump to a page press :, enter a number, then press enter
     pub const go_to_page = .{ .key = ':', .modifiers = .{} };
     pub const enter = .{ .key = '\r', .modifiers = .{} };
     pub const quit = .{ .key = 'c', .modifiers = .{ .ctrl = true } };

--- a/src/config.zig
+++ b/src/config.zig
@@ -8,6 +8,7 @@ pub const KeyMap = struct {
     pub const scroll_right = .{ .key = 'l', .modifiers = .{} };
     pub const zoom_in = .{ .key = 'i', .modifiers = .{} };
     pub const zoom_out = .{ .key = 'o', .modifiers = .{} };
+    pub const go_to_page = .{ .key = 'g', .modifiers = .{} };
     pub const quit = .{ .key = 'c', .modifiers = .{ .ctrl = true } };
 };
 


### PR DESCRIPTION
This is a modification of https://github.com/freref/fancy-cat/pull/17 that uses vi style keys to change pages.

Type `:`, enter a number, then press enter to jump to the page.

There aren't really usage instructions yet so I just added a comment to the config for now.

The `is_changing_page` flag isn't strictly required for this change but I thought it would be good to keep in case more uses for number keys appear in the future.