### PR TITLE
Colorized mode

### DIFF
--- a/src/View.zig
+++ b/src/View.zig
@@ -154,6 +154,8 @@ fn handleKeyStroke(self: *Self, key: vaxis.Key) !void {
         self.pdf_handler.scroll(.Left);
     } else if (key.matches(km.scroll_right.key, km.scroll_right.modifiers)) {
         self.pdf_handler.scroll(.Right);
+    } else if (key.matches(km.colorize.key, km.colorize.modifiers)) {
+        self.pdf_handler.toggleColor();
     }
 
     self.reload = true;

--- a/src/config.zig
+++ b/src/config.zig
@@ -8,6 +8,7 @@ pub const KeyMap = struct {
     pub const scroll_right = .{ .key = 'l', .modifiers = .{} };
     pub const zoom_in = .{ .key = 'i', .modifiers = .{} };
     pub const zoom_out = .{ .key = 'o', .modifiers = .{} };
+    pub const colorize = .{ .key = 'z', .modifiers = .{} };
     pub const quit = .{ .key = 'c', .modifiers = .{ .ctrl = true } };
 };
 
@@ -19,7 +20,9 @@ pub const FileMonitor = struct {
 };
 
 pub const General = struct {
-    pub const darkmode: bool = false;
+    pub const colorize: bool = false;
+    pub const white: u32 = 0x000000;
+    pub const black: u32 = 0xffffff;
     // size of the pdf
     // 1 is the whole screen
     pub const size: f32 = 0.90;


### PR DESCRIPTION
This feature is a generalization of the current dark mode. It enables users to replace the black and white colors of documents with custom colors to achieve a seamless viewing experience. See #38.

Usage notes: 

- A keymap (z in the implementation) enables users to toggle between normal (light) mode and colorized (dark) mode.
- The parameter "colorize" sets the colorized mode as the default mode when opening a document.
- The parameters "white" and "black" correspond to the colors used to replace white and black, respectively.