### PR TITLE
chore: update version and add license in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ zig build run -- <path-to-pdf> <optional-page-number>
 - ✅ Page navigation (zoom, etc.)
 - ✅ Status bar
 
+## License
+
+spdx-license-identifier: AGPL-3.0-or-later
+
 ## Contributing
 
 Contributions are welcome.

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = "fancy-cat",
-    .version = "0.3.0",
+    .version = "0.3.1",
     .minimum_zig_version = "0.13.0",
     .dependencies = .{
         .vaxis = .{

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const Context = @import("Context.zig").Context;
 
-pub const FANCY_CAT_VERSION = "0.3.0";
+pub const FANCY_CAT_VERSION = "0.3.1";
 
 pub fn main() !void {
     const args = try std.process.argsAlloc(std.heap.page_allocator);


### PR DESCRIPTION
👋 actually the version did not get updated per 0.3.1 tag, so update it to match with the tag.

Also since license has been updated to [AGPL-3.0](https://spdx.org/licenses/AGPL-3.0), and add license field in README as well (note [AGPL-3.0](https://spdx.org/licenses/AGPL-3.0) is deprecated SPDX identifier, so specifying as [AGPL-3.0-or-later](https://spdx.org/licenses/AGPL-3.0-or-later))

----

relates to https://github.com/Homebrew/homebrew-core/pull/209090