### PR TITLE
Preview usability

### DIFF
--- a/src/Cache.zig
+++ b/src/Cache.zig
@@ -20,8 +20,15 @@ tail: ?*Node,
 config: *Config,
 lru_size: usize,
 mutex: std.Thread.Mutex,
+vx: vaxis.Vaxis,
+tty: *const vaxis.Tty,
 
-pub fn init(allocator: std.mem.Allocator, config: *Config) Self {
+pub fn init(
+    allocator: std.mem.Allocator,
+    config: *Config,
+    vx: vaxis.Vaxis,
+    tty: *const vaxis.Tty,
+) Self {
     return .{
         .allocator = allocator,
         .map = std.AutoHashMap(Key, *Node).init(allocator),
@@ -30,18 +37,25 @@ pub fn init(allocator: std.mem.Allocator, config: *Config) Self {
         .config = config,
         .lru_size = config.cache.lru_size,
         .mutex = .{},
+        .vx = vx,
+        .tty = tty,
     };
 }
 
 pub fn deinit(self: *Self) void {
     self.mutex.lock();
     defer self.mutex.unlock();
+
     var current = self.head;
     while (current) |node| {
         const next = node.next;
+
+        self.vx.freeImage(self.tty.anyWriter(), node.value.image.id);
         self.allocator.destroy(node);
+
         current = next;
     }
+
     self.map.deinit();
 }
 
@@ -51,10 +65,8 @@ pub fn clear(self: *Self) void {
 
     var current = self.head;
     while (current) |node| {
-        // TODO clear the image from the terminal everywhere
-        // Currently assuming the terminal takes care of it somewhat
-        //self.vx.freeImage(self.tty.anyWriter(), node.value.image.id);
         const next = node.next;
+        // To avoid flicker, image is freed during put eviction
         self.allocator.destroy(node);
         current = next;
     }
@@ -67,6 +79,7 @@ pub fn clear(self: *Self) void {
 pub fn get(self: *Self, key: Key) ?CachedImage {
     self.mutex.lock();
     defer self.mutex.unlock();
+
     const node = self.map.get(key) orelse return null;
     self.moveToFront(node);
     return node.value;
@@ -75,6 +88,7 @@ pub fn get(self: *Self, key: Key) ?CachedImage {
 pub fn put(self: *Self, key: Key, image: CachedImage) !bool {
     self.mutex.lock();
     defer self.mutex.unlock();
+
     if (self.map.get(key)) |node| {
         self.moveToFront(node);
         return false;
@@ -94,6 +108,8 @@ pub fn put(self: *Self, key: Key, image: CachedImage) !bool {
     if (self.map.count() > self.lru_size) {
         const tail_node = self.tail orelse unreachable;
         _ = self.map.remove(tail_node.key);
+
+        self.vx.freeImage(self.tty.anyWriter(), tail_node.value.image.id);
         self.removeNode(tail_node);
         self.allocator.destroy(tail_node);
     }
@@ -106,8 +122,9 @@ pub fn remove(self: *Self, key: Key) bool {
     defer self.mutex.unlock();
 
     const node = self.map.get(key) orelse return false;
-
     _ = self.map.remove(key);
+
+    self.vx.freeImage(self.tty.anyWriter(), node.value.image.id);
     self.removeNode(node);
     self.allocator.destroy(node);
 

--- a/src/Cache.zig
+++ b/src/Cache.zig
@@ -3,7 +3,14 @@ const std = @import("std");
 const Config = @import("config/Config.zig");
 const vaxis = @import("vaxis");
 
-pub const Key = struct { colorize: bool, page: u16, width_mode: bool };
+pub const Key = struct {
+    colorize: bool,
+    page: u16,
+    width_mode: bool,
+    zoom: u32,
+    x_offset: i32,
+    y_offset: i32,
+};
 pub const CachedImage = struct { image: vaxis.Image };
 
 const Node = struct {

--- a/src/Context.zig
+++ b/src/Context.zig
@@ -75,7 +75,7 @@ pub const Context = struct {
             .config = config,
             .current_mode = undefined,
             .reload_page = true,
-            .cache = Cache.init(allocator, config),
+            .cache = Cache.init(allocator, config, vx, &tty),
             .should_check_cache = config.cache.enabled,
         };
     }
@@ -193,11 +193,7 @@ pub const Context = struct {
             },
             .file_changed => {
                 try self.document_handler.reloadDocument();
-                _ = self.cache.remove(.{
-                    .colorize = self.config.general.colorize,
-                    .page = self.document_handler.current_page_number,
-                    .width_mode = self.document_handler.getWidthMode(),
-                });
+                self.cache.clear();
                 self.reload_page = true;
             },
         }

--- a/src/Context.zig
+++ b/src/Context.zig
@@ -205,15 +205,19 @@ pub const Context = struct {
         window_width: u32,
         window_height: u32,
     ) !vaxis.Image {
+        const cache_key = Cache.Key{
+            .colorize = self.config.general.colorize,
+            .page = page_number,
+            .width_mode = self.document_handler.getWidthMode(),
+
+            // Scale zoom and position as integers with three digits of precision for use in key
+            .zoom = @as(u32, @intFromFloat(self.document_handler.getActiveZoom() * 1000.0)),
+            .x_offset = @as(i32, @intFromFloat(self.document_handler.getXOffset() * 1000.0)),
+            .y_offset = @as(i32, @intFromFloat(self.document_handler.getYOffset() * 1000.0)),
+        };
+
         if (self.should_check_cache) {
-            if (self.cache.get(.{
-                .colorize = self.config.general.colorize,
-                .page = page_number,
-                .width_mode = self.document_handler.getWidthMode(),
-            })) |cached| {
-                // Once we get the cached image we don't need to check the cache anymore because
-                // The only actions a user can take is zoom or scrolling, but we don't cache those
-                // Or go to the next page, at which point we set check_cache to true again
+            if (self.cache.get(cache_key)) |cached| {
                 self.should_check_cache = false;
                 return cached.image;
             }
@@ -234,14 +238,10 @@ pub const Context = struct {
             .rgb,
         );
 
-        if (!self.should_check_cache) return image;
-
-        _ = try self.cache.put(.{
-            .colorize = self.config.general.colorize,
-            .page = page_number,
-            .width_mode = self.document_handler.getWidthMode(),
-        }, .{ .image = image });
-        self.should_check_cache = false;
+        if (self.should_check_cache) {
+            _ = try self.cache.put(cache_key, .{ .image = image });
+            self.should_check_cache = false;
+        }
 
         return image;
     }

--- a/src/Context.zig
+++ b/src/Context.zig
@@ -163,7 +163,6 @@ pub const Context = struct {
     }
 
     pub fn resetCurrentPage(self: *Self) void {
-        self.document_handler.resetZoomAndScroll();
         self.should_check_cache = self.config.cache.enabled;
         self.reload_page = true;
     }
@@ -189,8 +188,6 @@ pub const Context = struct {
             .mouse => |mouse| self.mouse = mouse,
             .winsize => |ws| {
                 try self.vx.resize(self.allocator, self.tty.anyWriter(), ws);
-                self.document_handler.resetDefaultZoom();
-                self.document_handler.resetZoomAndScroll();
                 self.cache.clear();
                 self.reload_page = true;
             },

--- a/src/handlers/DocumentHandler.zig
+++ b/src/handlers/DocumentHandler.zig
@@ -129,3 +129,15 @@ pub fn getPath(self: *Self) []const u8 {
 pub fn getTotalPages(self: *Self) u16 {
     return self.pdf_handler.total_pages;
 }
+
+pub fn getActiveZoom(self: *Self) f32 {
+    return self.pdf_handler.active_zoom;
+}
+
+pub fn getXOffset(self: *Self) f32 {
+    return self.pdf_handler.x_offset;
+}
+
+pub fn getYOffset(self: *Self) f32 {
+    return self.pdf_handler.y_offset;
+}


### PR DESCRIPTION
This pull request enhances live preview usability through a series of three related fixes:

**1. View preservation on window resize and page change**

Losing a precisely set view during focused edits can be very frustrating. This fix preserves zoom level and scroll position on window resize and page changes, matching the behavior of typical PDF viewers.

**2. Amended fix for #80**

The fix in #81 only removes the visible page from the cache on file change, but changes can occur on any page. This fix clears all cached pages on file change.

**3. Enhanced cache indexing**

The cache now includes zoom level and scroll position as part of its indexing, ensuring that the cached content is only reused for the same view.

This update also lays the groundwork for zoom and scroll commands in command mode.



 





