### PR TITLE
feat: scroll commands for precise navigation

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -5,3 +5,5 @@ These are the commands that can be executed:
 - `:q` — quit
 - `:<number>%` — set zoom level
 - `:<number>` — go to page number
+- `:x+<number>` / `:x-<number>` — scroll right (`+`) or left (`-`) by the given amount (e.g. `:x+10.5`)
+- `:y+<number>` / `:y-<number>` — scroll up (`+`) or down (`-`) by the given amount (e.g. `:y-3.1`)

--- a/src/handlers/DocumentHandler.zig
+++ b/src/handlers/DocumentHandler.zig
@@ -76,6 +76,10 @@ pub fn zoomOut(self: *Self) void {
     self.pdf_handler.zoomOut();
 }
 
+pub fn setZoom(self: *Self, zoom_factor: f32) void {
+    self.pdf_handler.active_zoom = @max(zoom_factor, self.pdf_handler.config.general.zoom_min);
+}
+
 pub fn toggleColor(self: *Self) void {
     self.pdf_handler.toggleColor();
 }
@@ -95,6 +99,7 @@ pub fn resetZoomAndScroll(self: *Self) void {
 pub fn toggleWidthMode(self: *Self) void {
     self.pdf_handler.toggleWidthMode();
 }
+
 pub fn goToPage(self: *Self, page_num: u16) bool {
     if (page_num >= 1 and page_num <= self.getTotalPages() and page_num != self.current_page_number + 1) {
         self.current_page_number = @as(u16, @intCast(page_num)) - 1;
@@ -102,6 +107,7 @@ pub fn goToPage(self: *Self, page_num: u16) bool {
     }
     return false;
 }
+
 pub fn changePage(self: *Self, delta: i32) bool {
     const new_page = @as(i32, @intCast(self.current_page_number)) + delta;
 
@@ -140,10 +146,4 @@ pub fn getXOffset(self: *Self) f32 {
 
 pub fn getYOffset(self: *Self) f32 {
     return self.pdf_handler.y_offset;
-}
-
-// setters
-
-pub fn setZoom(self: *Self, zoom_factor: f32) void {
-    self.pdf_handler.active_zoom = @max(zoom_factor, self.pdf_handler.config.general.zoom_min);
 }

--- a/src/handlers/DocumentHandler.zig
+++ b/src/handlers/DocumentHandler.zig
@@ -88,6 +88,10 @@ pub fn scroll(self: *Self, direction: types.ScrollDirection) void {
     self.pdf_handler.scroll(direction);
 }
 
+pub fn offsetScroll(self: *Self, dx: f32, dy: f32) void {
+    self.pdf_handler.offsetScroll(dx, dy);
+}
+
 pub fn resetDefaultZoom(self: *Self) void {
     self.pdf_handler.resetDefaultZoom();
 }

--- a/src/handlers/PdfHandler.zig
+++ b/src/handlers/PdfHandler.zig
@@ -268,6 +268,11 @@ pub fn scroll(self: *Self, direction: types.ScrollDirection) void {
     }
 }
 
+pub fn offsetScroll(self: *Self, dx: f32, dy: f32) void {
+    self.x_offset -= dx;
+    self.y_offset += dy;
+}
+
 pub fn resetDefaultZoom(self: *Self) void {
     self.default_zoom = 0;
 }

--- a/src/modes/CommandMode.zig
+++ b/src/modes/CommandMode.zig
@@ -65,6 +65,22 @@ pub fn executeCommand(self: *Self, cmd: []const u8) void {
         return;
     }
 
+    if (cmd_str.len >= 3) {
+        const axis = cmd_str[0];
+        const sign = cmd_str[1];
+        if ((axis == 'x' or axis == 'y') and (sign == '+' or sign == '-')) {
+            const number_str = cmd_str[2..];
+            if (std.fmt.parseFloat(f32, number_str)) |amount| {
+                const delta = if (sign == '+') amount else -amount;
+                const dx: f32 = if (axis == 'x') delta else 0.0;
+                const dy: f32 = if (axis == 'y') delta else 0.0;
+                self.context.document_handler.offsetScroll(dx, dy);
+                self.context.resetCurrentPage();
+            } else |_| {}
+            return;
+        }
+    }
+
     if (std.mem.endsWith(u8, cmd_str, "%")) {
         const number_str = cmd_str[0 .. cmd_str.len - 1];
         if (std.fmt.parseFloat(f32, number_str)) |percent| {


### PR DESCRIPTION
This pull request introduces command-mode scrolling to support workflows that require precise navigation (such as inspecting typesetting quality).

#### New commands:

- `:x+<number>` / `:x-<number>` — Scroll right (`+`) or left (`–`) by the given amount (e.g., `:x+10.5`)  
- `:y+<number>` / `:y-<number>` — Scroll up (`+`) or down (`–`) by the given amount (e.g., `:y-3.1`)

Note: These commands only take effect when the page is zoomed in far enough to allow scrolling.