### PR TITLE
feat: command history

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,15 @@ fancy-cat <path-to-pdf> <optional-page-number>
 
 ### Commands
 
-fancy-cat uses a modal interface similar to Neovim. There are two modes: view mode and command mode. To enter command mode you type `:` by default (this can be changed in the config file)
+fancy-cat uses a modal interface similar to Neovim. There are two modes: view mode and command mode. To enter command mode you type `:` by default (this can be changed in the config file).
 
-Documentation on the available commands can be found [here](./docs/commands.md)
+Documentation on the available commands can be found [here](./docs/commands.md).
 
 ### Configuration
 
-fancy-cat can be configured through a JSON config file located at `~/.config/fancy-cat/config.json`. The file is automatically created on the first run with default settings.
+fancy-cat can be configured through a JSON configuration file located in one of several locations (primary `$XDG_CONFIG_HOME/fancy-cat/config.json`, fallback `$HOME/.config/fancy-cat/config.json`, legacy `$HOME/.fancy-cat`). An empty configuration file is automatically created in the primary or fallback location on the first run.
 
-The default `config.json` and documentation can be found [here](./docs/config.md)
+An example `config.json` and documentation can be found [here](./docs/config.md).
 
 ## Installation
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,16 +1,30 @@
 # Configuration
 
-On startup, fancy-cat looks for a configuration file at:
+On startup, fancy-cat looks for a configuration file in the following locations:
+
+**Primary**
 
 ```
-~/.config/fancy-cat/config.json
+$XDG_CONFIG_HOME/fancy-cat/config.json
 ```
 
-If no configuration file is found, fancy-cat creates an empty one. Since fancy-cat comes with sensible defaults, you only need to add the options you want to change.
+**Fallback**
+
+```
+$HOME/.config/fancy-cat/config.json
+```
+
+**Legacy**
+
+```
+$HOME/.fancy-cat
+```
+
+If no configuration file is found in any of these locations, fancy-cat creates an empty configuration file in the primary or fallback location.
 
 ## Defaults
 
-Below is an example configuration file that replicates the default settings. You can use it as a starting point for your customizations:
+Because fancy-cat provides sensible defaults, you only need to specify the options you wish to override. Below is an example configuration file that replicates the default settings. You can use this example as a starting point for your customizations:
 
 ```json
 {
@@ -80,6 +94,7 @@ The rest of this reference provides detailed explanations for each configuration
 - [File Monitor](#file-monitor)
 - [General](#general)
   - [Color](#color)
+  - [History](#history)
 - [Status Bar](#status-bar)
   - [Style](#style)
     - [Underline](#underline)
@@ -209,6 +224,30 @@ The following color formats are supported:
 | :---  | :--- |
 | `"#RRGGBB"` or `"0xRRGGBB"` | `RR`, `GG`, and `BB` are two-digit hexadecimal values |
 | `{ "rgb": [R, G, B] }` | `R`, `G`, and `B` are integers between 0 and 255 |
+
+### History
+
+To ensure persistence across sessions, fancy-cat saves its command history in one of the following locations:
+
+**Primary**
+
+```
+$XDG_STATE_HOME/fancy-cat/history
+```
+
+**Fallback**
+
+```
+$HOME/.local/state/fancy-cat/history
+```
+
+**Legacy**
+
+```
+$HOME/.fancy-cat_history
+```
+>[!NOTE]
+>The legacy location is only used if the [configuration file](#configuration) itself is located at `$HOME/.fancy-cat`.
 
 ---
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -29,7 +29,9 @@ Below is an example configuration file that replicates the default settings. You
     "full_screen": { "key": "f"},
     "enter_command_mode": { "key": ":" },
     "exit_command_mode": { "key": "escape" },
-    "execute_command": { "key": "enter" }
+    "execute_command": { "key": "enter" },
+    "history_back": { "key": "up" },
+    "history_forward": { "key": "down" }
   },
   "FileMonitor": {
     "enabled": true,
@@ -46,7 +48,8 @@ Below is an example configuration file that replicates the default settings. You
     "scroll_step": 100.0,
     "retry_delay": 0.2,
     "timeout": 5.0,
-    "dpi": 96.0
+    "dpi": 96.0,
+    "history": 1000
   },
   "StatusBar": {
     "enabled": true,
@@ -110,6 +113,8 @@ The `KeyMap` section defines keybindings for various actions.
 | `enter_command_mode` | Enter command mode |
 | `exit_command_mode` | Exit command mode |
 | `execute_command` | Execute the entered command |
+| `history_back` | Go back one command in history |
+| `history_forward` | Go forward one command in history |
 
 ### Keybindings
 
@@ -191,6 +196,7 @@ The `General` section includes various display and timing settings.
 | `dpi` | Float | Resolution used for 100% zoom calculation |
 | `retry_delay` | Float (seconds) | Delay before retrying to load a document or render a page |
 | `timeout` | Float (seconds) | Maximum time to keep retrying before giving up on loading a document or rendering a page |
+| `history` | Integer | Maximum number of entries in command history |
 
 >[!TIP]
 >The color replacement feature works by replacing white and black with custom colors, which also affects the full color range depending on contrast. By default, `white` is set to black (`#000000`) and `black` is set to white (`#ffffff`). For a seamless look, try setting `white` to match your terminal’s background color and `black` to match the foreground (text) color.

--- a/src/Context.zig
+++ b/src/Context.zig
@@ -56,7 +56,7 @@ pub const Context = struct {
 
         const config = try allocator.create(Config);
         errdefer allocator.destroy(config);
-        config.* = try Config.init(allocator);
+        config.* = Config.init(allocator);
         errdefer config.deinit();
 
         var document_handler = try DocumentHandler.init(allocator, path, initial_page, config);

--- a/src/Context.zig
+++ b/src/Context.zig
@@ -107,14 +107,14 @@ pub const Context = struct {
 
         if (self.page_info_text.len > 0) self.allocator.free(self.page_info_text);
 
-        self.config.deinit();
-        self.allocator.destroy(self.config);
-        self.arena.deinit();
         self.reload_indicator_timer.deinit();
         self.cache.deinit();
         self.document_handler.deinit();
         self.vx.deinit(self.allocator, self.tty.writer());
         self.tty.deinit();
+        self.config.deinit();
+        self.allocator.destroy(self.config);
+        self.arena.deinit();
         self.allocator.free(self.buf);
     }
 

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -18,6 +18,8 @@ pub const KeyMap = struct {
     enter_command_mode: vaxis.Key = .{ .codepoint = ':' },
     exit_command_mode: vaxis.Key = .{ .codepoint = vaxis.Key.escape },
     execute_command: vaxis.Key = .{ .codepoint = vaxis.Key.enter },
+    history_back: vaxis.Key = .{ .codepoint = vaxis.Key.up },
+    history_forward: vaxis.Key = .{ .codepoint = vaxis.Key.down },
 
     pub fn parse(val: std.json.Value, allocator: std.mem.Allocator) KeyMap {
         var keymap = KeyMap{};
@@ -87,6 +89,8 @@ pub const General = struct {
     timeout: f32 = 5.0,
     // resolution
     dpi: f32 = 96.0,
+    // whole number (possibly 0)
+    history: u32 = 1000,
 
     pub fn parse(val: std.json.Value, allocator: std.mem.Allocator) General {
         var general = General{};
@@ -116,6 +120,7 @@ pub const General = struct {
         general.retry_delay = parseType(f32, val.object, "retry_delay", allocator, general.retry_delay);
         general.timeout = parseType(f32, val.object, "timeout", allocator, general.timeout);
         general.dpi = parseType(f32, val.object, "dpi", allocator, general.dpi);
+        general.history = parseType(u32, val.object, "history", allocator, general.history);
 
         return general;
     }

--- a/src/modes/CommandMode.zig
+++ b/src/modes/CommandMode.zig
@@ -31,7 +31,9 @@ pub fn handleKeyStroke(self: *Self, key: vaxis.Key, km: Config.KeyMap) !void {
     }
 
     if (key.matches(km.execute_command.codepoint, km.execute_command.mods)) {
-        self.executeCommand(self.text_input.buf.firstHalf());
+        const cmd = try self.text_input.buf.toOwnedSlice();
+        defer self.context.allocator.free(cmd);
+        self.executeCommand(cmd);
         self.context.changeMode(.view);
         return;
     }

--- a/src/modes/CommandMode.zig
+++ b/src/modes/CommandMode.zig
@@ -48,14 +48,7 @@ pub fn drawCommandBar(self: *Self, win: vaxis.Window) void {
     });
     _ = command_bar.print(&.{.{ .text = ":" }}, .{ .col_offset = 0 });
 
-    const child = win.child(.{
-        .x_off = 1,
-        .y_off = win.height - 1,
-        .width = win.width,
-        .height = 1,
-    });
-
-    self.text_input.draw(child);
+    self.text_input.draw(command_bar.child(.{ .x_off = 1 }));
 }
 
 pub fn executeCommand(self: *Self, cmd: []const u8) void {

--- a/src/services/History.zig
+++ b/src/services/History.zig
@@ -6,6 +6,7 @@ allocator: std.mem.Allocator,
 config: *Config,
 items: std.ArrayList([]const u8),
 index: isize,
+path: []u8,
 
 pub fn init(allocator: std.mem.Allocator, config: *Config) Self {
     var self = Self{
@@ -13,6 +14,7 @@ pub fn init(allocator: std.mem.Allocator, config: *Config) Self {
         .config = config,
         .items = .{},
         .index = -1,
+        .path = "",
     };
 
     if (config.general.history <= 0) return self;
@@ -20,16 +22,19 @@ pub fn init(allocator: std.mem.Allocator, config: *Config) Self {
     const home = std.process.getEnvVarOwned(allocator, "HOME") catch return self;
     defer allocator.free(home);
 
-    var history_path_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const history_path = std.fmt.bufPrint(&history_path_buf, "{s}/.local/state/fancy-cat/history.txt", .{home}) catch return self;
+    if (!config.legacy_path) {
+        const xdg_state_home = std.process.getEnvVarOwned(allocator, "XDG_STATE_HOME") catch null;
+        if (xdg_state_home) |x| {
+            self.path = std.fmt.allocPrint(allocator, "{s}/fancy-cat/history", .{x}) catch return self;
+            allocator.free(x);
+        } else self.path = std.fmt.allocPrint(allocator, "{s}/.local/state/fancy-cat/history", .{home}) catch return self;
+    } else self.path = std.fmt.allocPrint(allocator, "{s}/.fancy-cat_history", .{home}) catch return self;
 
-    const file = std.fs.openFileAbsolute(history_path, .{ .mode = .read_only }) catch return self;
-    defer file.close();
+    const content = std.fs.cwd().readFileAlloc(allocator, self.path, 1024 * 1024) catch null;
+    if (content == null) return self;
+    defer allocator.free(content.?);
 
-    const content = file.readToEndAlloc(allocator, 1024 * 1024) catch return self;
-    defer allocator.free(content);
-
-    var line = std.mem.tokenizeScalar(u8, content, '\n');
+    var line = std.mem.tokenizeScalar(u8, content.?, '\n');
     while (line.next()) |cmd| {
         const cmd_copy = allocator.dupe(u8, cmd) catch continue;
         self.items.append(allocator, cmd_copy) catch {
@@ -42,29 +47,16 @@ pub fn init(allocator: std.mem.Allocator, config: *Config) Self {
 }
 
 pub fn deinit(self: *Self) void {
-    defer {
-        for (self.items.items) |entry| {
-            self.allocator.free(entry);
-        }
-        self.items.deinit(self.allocator);
-    }
-
     if (self.config.general.history <= 0) return;
 
-    const home = std.process.getEnvVarOwned(self.allocator, "HOME") catch return;
-    defer self.allocator.free(home);
+    defer {
+        for (self.items.items) |entry| self.allocator.free(entry);
+        self.items.deinit(self.allocator);
+        if (self.path.len > 0) self.allocator.free(self.path);
+    }
 
-    var history_dir_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const history_dir = std.fmt.bufPrint(&history_dir_buf, "{s}/.local/state/fancy-cat", .{home}) catch return;
-
-    std.fs.makeDirAbsolute(history_dir) catch |err| {
-        if (err != error.PathAlreadyExists) return;
-    };
-
-    var history_path_buf: [std.fs.max_path_bytes]u8 = undefined;
-    const history_path = std.fmt.bufPrint(&history_path_buf, "{s}/history.txt", .{history_dir}) catch return;
-
-    const file = std.fs.createFileAbsolute(history_path, .{}) catch return;
+    if (std.fs.path.dirname(self.path)) |dir| std.fs.cwd().makePath(dir) catch {};
+    const file = std.fs.createFileAbsolute(self.path, .{}) catch return;
     defer file.close();
 
     for (self.items.items) |cmd| {

--- a/src/services/History.zig
+++ b/src/services/History.zig
@@ -1,0 +1,99 @@
+const Self = @This();
+const std = @import("std");
+const Config = @import("../config/Config.zig");
+
+allocator: std.mem.Allocator,
+config: *Config,
+items: std.ArrayList([]const u8),
+index: isize,
+
+pub fn init(allocator: std.mem.Allocator, config: *Config) Self {
+    var self = Self{
+        .allocator = allocator,
+        .config = config,
+        .items = .{},
+        .index = -1,
+    };
+
+    if (config.general.history <= 0) return self;
+
+    const home = std.process.getEnvVarOwned(allocator, "HOME") catch return self;
+    defer allocator.free(home);
+
+    var history_path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const history_path = std.fmt.bufPrint(&history_path_buf, "{s}/.local/state/fancy-cat/history.txt", .{home}) catch return self;
+
+    const file = std.fs.openFileAbsolute(history_path, .{ .mode = .read_only }) catch return self;
+    defer file.close();
+
+    const content = file.readToEndAlloc(allocator, 1024 * 1024) catch return self;
+    defer allocator.free(content);
+
+    var line = std.mem.tokenizeScalar(u8, content, '\n');
+    while (line.next()) |cmd| {
+        const cmd_copy = allocator.dupe(u8, cmd) catch continue;
+        self.items.append(allocator, cmd_copy) catch {
+            allocator.free(cmd_copy);
+            continue;
+        };
+    }
+
+    return self;
+}
+
+pub fn deinit(self: *Self) void {
+    defer {
+        for (self.items.items) |entry| {
+            self.allocator.free(entry);
+        }
+        self.items.deinit(self.allocator);
+    }
+
+    if (self.config.general.history <= 0) return;
+
+    const home = std.process.getEnvVarOwned(self.allocator, "HOME") catch return;
+    defer self.allocator.free(home);
+
+    var history_dir_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const history_dir = std.fmt.bufPrint(&history_dir_buf, "{s}/.local/state/fancy-cat", .{home}) catch return;
+
+    std.fs.makeDirAbsolute(history_dir) catch |err| {
+        if (err != error.PathAlreadyExists) return;
+    };
+
+    var history_path_buf: [std.fs.max_path_bytes]u8 = undefined;
+    const history_path = std.fmt.bufPrint(&history_path_buf, "{s}/history.txt", .{history_dir}) catch return;
+
+    const file = std.fs.createFileAbsolute(history_path, .{}) catch return;
+    defer file.close();
+
+    for (self.items.items) |cmd| {
+        file.writeAll(cmd) catch continue;
+        file.writeAll("\n") catch continue;
+    }
+}
+
+pub fn addToHistory(self: *Self, cmd: []const u8) void {
+    if (self.config.general.history <= 0) return;
+
+    for (self.items.items, 0..) |existing_cmd, i| {
+        if (std.mem.eql(u8, existing_cmd, cmd)) {
+            self.allocator.free(self.items.orderedRemove(i));
+            break;
+        }
+    }
+
+    const cmd_copy = self.allocator.dupe(u8, cmd) catch return;
+    self.items.append(self.allocator, cmd_copy) catch {
+        self.allocator.free(cmd_copy);
+        return;
+    };
+
+    const max: usize = self.config.general.history;
+    while (self.items.items.len > max) {
+        const removed = self.items.orderedRemove(0);
+        self.allocator.free(removed);
+    }
+
+    self.index = -1;
+}


### PR DESCRIPTION
This PR introduces command history.

**Navigation:** Pressing the up and down arrow keys (customizable) in command mode cycles through previous commands.

**Persistence:** History is automatically saved across sessions.

**Filtering:** Typing the initial characters of a command filters the history for faster recall.

With filtering, this update also appears to resolve issue #63.