### PR TITLE
feat: multiplied zoom and scroll actions

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -32,11 +32,17 @@ Because fancy-cat provides sensible defaults, you only need to specify the optio
     "next": { "key": "n" },
     "prev": { "key": "p" },
     "scroll_up": { "key": "k" },
+    "scroll_up_mult": { "key": "k", "modifiers": [ "shift" ] },
     "scroll_down": { "key": "j" },
+    "scroll_down_mult": { "key": "j", "modifiers": [ "shift" ] },
     "scroll_left": { "key": "h" },
+    "scroll_left_mult": { "key": "h", "modifiers": [ "shift" ] },
     "scroll_right": { "key": "l" },
+    "scroll_right_mult": { "key": "l", "modifiers": [ "shift" ] },
     "zoom_in": { "key": "i" },
+    "zoom_in_mult": { "key": "i", "modifiers": [ "shift" ] },
     "zoom_out": { "key": "o" },
+    "zoom_out_mult": { "key": "o", "modifiers": [ "shift" ] },
     "width_mode": { "key": "w" },
     "colorize": { "key": "z" },
     "quit": { "key": "c", "modifiers": [ "ctrl" ] },
@@ -58,8 +64,10 @@ Because fancy-cat provides sensible defaults, you only need to specify the optio
     "black": "#ffffff",
     "size": 1.0,
     "zoom_step": 1.25,
+    "zoom_mult": 2.0,
     "zoom_min": 1.0,
     "scroll_step": 100.0,
+    "scroll_mult": 10.0,
     "retry_delay": 0.2,
     "timeout": 5.0,
     "detect_dpi": true,
@@ -117,11 +125,17 @@ The `KeyMap` section defines keybindings for various actions.
 | `next` | Go to the next page |
 | `prev` | Go to the previous page |
 | `scroll_up` | Move the viewport up |
+| `scroll_up_mult` | Multiplied `scroll_up` |
 | `scroll_down` | Move the viewport down |
+| `scroll_down_mult` | Multiplied `scroll_down` |
 | `scroll_left` | Move the viewport left |
+| `scroll_left_mult` | Multiplied `scroll_left` |
 | `scroll_right` | Move the viewport right |
+| `scroll_right_mult` | Multiplied `scroll_right` |
 | `zoom_in` | Increase the zoom level |
+| `zoom_in_mult` | Multiplied `zoom_in` |
 | `zoom_out` | Decrease the zoom level |
+| `zoom_out_mult` | Multiplied `zoom_out` |
 | `width_mode` | Toggle between full-height or full-width mode |
 | `colorize` | Toggle color replacement |
 | `quit` | Exit the program |
@@ -207,8 +221,10 @@ The `General` section includes various display and timing settings.
 | `black` | [Color](#color) | Replacement color for black |
 | `size` | Float | Initial zoom level multiplier (`1.0` fits the full height) |
 | `zoom_step` | Float | Zoom multiplier per keystroke |
+| `zoom_mult` | Float | Extra zoom multiplier for multiplied zoom actions |
 | `zoom_min` | Float | Minimum zoom level allowed |
 | `scroll_step` | Float (pixels) | Distance the viewport moves per scroll keystroke |
+| `scroll_mult` | Float | Scroll multiplier for multiplied scroll actions |
 | `detect_dpi` | Boolean | Enables pixel-density detection so that 100% zoom = actual size |
 | `dpi` | Float | Pixel density to use if `detect_dpi` is false, or fallback if detection fails |
 | `retry_delay` | Float (seconds) | Delay before retrying to load a document or render a page |

--- a/src/Context.zig
+++ b/src/Context.zig
@@ -182,6 +182,8 @@ pub const Context = struct {
             var buffered = self.tty.writer();
             try self.vx.render(buffered);
             try buffered.flush();
+
+            _ = self.arena.reset(.retain_capacity); // clear key actions from heap
         }
     }
 

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -6,11 +6,17 @@ pub const KeyMap = struct {
     next: vaxis.Key = .{ .codepoint = 'n' },
     prev: vaxis.Key = .{ .codepoint = 'p' },
     scroll_up: vaxis.Key = .{ .codepoint = 'k' },
+    scroll_up_mult: vaxis.Key = .{ .codepoint = 'k', .mods = .{ .shift = true } },
     scroll_down: vaxis.Key = .{ .codepoint = 'j' },
+    scroll_down_mult: vaxis.Key = .{ .codepoint = 'j', .mods = .{ .shift = true } },
     scroll_left: vaxis.Key = .{ .codepoint = 'h' },
+    scroll_left_mult: vaxis.Key = .{ .codepoint = 'h', .mods = .{ .shift = true } },
     scroll_right: vaxis.Key = .{ .codepoint = 'l' },
+    scroll_right_mult: vaxis.Key = .{ .codepoint = 'l', .mods = .{ .shift = true } },
     zoom_in: vaxis.Key = .{ .codepoint = 'i' },
+    zoom_in_mult: vaxis.Key = .{ .codepoint = 'i', .mods = .{ .shift = true } },
     zoom_out: vaxis.Key = .{ .codepoint = 'o' },
+    zoom_out_mult: vaxis.Key = .{ .codepoint = 'o', .mods = .{ .shift = true } },
     width_mode: vaxis.Key = .{ .codepoint = 'w' },
     colorize: vaxis.Key = .{ .codepoint = 'z' },
     quit: vaxis.Key = .{ .codepoint = 'c', .mods = .{ .ctrl = true } },
@@ -84,6 +90,9 @@ pub const General = struct {
     zoom_min: f32 = 1.0,
     // pixels
     scroll_step: f32 = 100.0,
+    // multiplier
+    zoom_mult: f32 = 2.0,
+    scroll_mult: f32 = 10.0,
     // seconds
     retry_delay: f32 = 0.2,
     timeout: f32 = 5.0,
@@ -118,6 +127,8 @@ pub const General = struct {
         general.zoom_step = parseType(f32, val.object, "zoom_step", allocator, general.zoom_step);
         general.zoom_min = parseType(f32, val.object, "zoom_min", allocator, general.zoom_min);
         general.scroll_step = parseType(f32, val.object, "scroll_step", allocator, general.scroll_step);
+        general.zoom_mult = parseType(f32, val.object, "zoom_mult", allocator, general.zoom_mult);
+        general.scroll_mult = parseType(f32, val.object, "scroll_mult", allocator, general.scroll_mult);
         general.retry_delay = parseType(f32, val.object, "retry_delay", allocator, general.retry_delay);
         general.timeout = parseType(f32, val.object, "timeout", allocator, general.timeout);
         general.detect_dpi = parseType(bool, val.object, "detect_dpi", allocator, general.detect_dpi);

--- a/src/handlers/DocumentHandler.zig
+++ b/src/handlers/DocumentHandler.zig
@@ -68,12 +68,12 @@ pub fn renderPage(
     return try self.pdf_handler.renderPage(page_number, window_width, window_height);
 }
 
-pub fn zoomIn(self: *Self) void {
-    self.pdf_handler.zoomIn();
+pub fn zoomIn(self: *Self, multiplier: f32) void {
+    self.pdf_handler.zoomIn(multiplier);
 }
 
-pub fn zoomOut(self: *Self) void {
-    self.pdf_handler.zoomOut();
+pub fn zoomOut(self: *Self, multiplier: f32) void {
+    self.pdf_handler.zoomOut(multiplier);
 }
 
 pub fn setZoom(self: *Self, percent: f32) void {
@@ -84,8 +84,8 @@ pub fn toggleColor(self: *Self) void {
     self.pdf_handler.toggleColor();
 }
 
-pub fn scroll(self: *Self, direction: types.ScrollDirection) void {
-    self.pdf_handler.scroll(direction);
+pub fn scroll(self: *Self, direction: types.ScrollDirection, multiplier: f32) void {
+    self.pdf_handler.scroll(direction, multiplier);
 }
 
 pub fn offsetScroll(self: *Self, dx: f32, dy: f32) void {

--- a/src/handlers/PdfHandler.zig
+++ b/src/handlers/PdfHandler.zig
@@ -220,12 +220,14 @@ pub fn renderPage(
     }
 }
 
-pub fn zoomIn(self: *Self) void {
-    self.active_zoom *= self.config.general.zoom_step;
+pub fn zoomIn(self: *Self, multiplier: f32) void {
+    const step = self.config.general.zoom_step * multiplier;
+    self.active_zoom *= step;
 }
 
-pub fn zoomOut(self: *Self) void {
-    self.active_zoom /= self.config.general.zoom_step;
+pub fn zoomOut(self: *Self, multiplier: f32) void {
+    const step = self.config.general.zoom_step * multiplier;
+    self.active_zoom /= step;
 }
 
 pub fn setZoom(self: *Self, percent: f32) void {
@@ -239,8 +241,8 @@ pub fn toggleColor(self: *Self) void {
     self.config.general.colorize = !self.config.general.colorize;
 }
 
-pub fn scroll(self: *Self, direction: types.ScrollDirection) void {
-    const step = self.config.general.scroll_step / self.active_zoom;
+pub fn scroll(self: *Self, direction: types.ScrollDirection, multiplier: f32) void {
+    const step = self.config.general.scroll_step * multiplier / self.active_zoom;
     switch (direction) {
         .Up => {
             const translation = self.y_offset + step;

--- a/src/modes/ViewMode.zig
+++ b/src/modes/ViewMode.zig
@@ -21,7 +21,8 @@ pub fn init(context: *Context) Self {
 pub fn handleKeyStroke(self: *Self, key: vaxis.Key, km: Config.KeyMap) !void {
     // O(n) but n is small
     // Centralized key handling
-    const key_actions = &[_]KeyAction{
+    const allocator = self.context.arena.allocator();
+    const key_actions = try allocator.dupe(KeyAction, &[_]KeyAction{
         .{
             .codepoint = km.next.codepoint,
             .mods = km.next.mods,
@@ -145,7 +146,7 @@ pub fn handleKeyStroke(self: *Self, key: vaxis.Key, km: Config.KeyMap) !void {
                 }
             }.action,
         },
-    };
+    });
 
     for (key_actions) |action| {
         if (key.matches(action.codepoint, action.mods)) {

--- a/src/modes/ViewMode.zig
+++ b/src/modes/ViewMode.zig
@@ -28,9 +28,7 @@ pub fn handleKeyStroke(self: *Self, key: vaxis.Key, km: Config.KeyMap) !void {
             .mods = km.next.mods,
             .handler = struct {
                 fn action(s: *Context) void {
-                    if (s.document_handler.changePage(1)) {
-                        s.resetCurrentPage();
-                    }
+                    if (s.document_handler.changePage(1)) s.resetCurrentPage();
                 }
             }.action,
         },
@@ -39,9 +37,7 @@ pub fn handleKeyStroke(self: *Self, key: vaxis.Key, km: Config.KeyMap) !void {
             .mods = km.prev.mods,
             .handler = struct {
                 fn action(s: *Context) void {
-                    if (s.document_handler.changePage(-1)) {
-                        s.resetCurrentPage();
-                    }
+                    if (s.document_handler.changePage(-1)) s.resetCurrentPage();
                 }
             }.action,
         },
@@ -50,7 +46,17 @@ pub fn handleKeyStroke(self: *Self, key: vaxis.Key, km: Config.KeyMap) !void {
             .mods = km.zoom_in.mods,
             .handler = struct {
                 fn action(s: *Context) void {
-                    s.document_handler.zoomIn();
+                    s.document_handler.zoomIn(1.0);
+                    s.reload_page = true;
+                }
+            }.action,
+        },
+        .{
+            .codepoint = km.zoom_in_mult.codepoint,
+            .mods = km.zoom_in_mult.mods,
+            .handler = struct {
+                fn action(s: *Context) void {
+                    s.document_handler.zoomIn(s.config.general.zoom_mult);
                     s.reload_page = true;
                 }
             }.action,
@@ -60,7 +66,17 @@ pub fn handleKeyStroke(self: *Self, key: vaxis.Key, km: Config.KeyMap) !void {
             .mods = km.zoom_out.mods,
             .handler = struct {
                 fn action(s: *Context) void {
-                    s.document_handler.zoomOut();
+                    s.document_handler.zoomOut(1.0);
+                    s.reload_page = true;
+                }
+            }.action,
+        },
+        .{
+            .codepoint = km.zoom_out_mult.codepoint,
+            .mods = km.zoom_out_mult.mods,
+            .handler = struct {
+                fn action(s: *Context) void {
+                    s.document_handler.zoomOut(s.config.general.zoom_mult);
                     s.reload_page = true;
                 }
             }.action,
@@ -92,7 +108,17 @@ pub fn handleKeyStroke(self: *Self, key: vaxis.Key, km: Config.KeyMap) !void {
             .mods = km.scroll_up.mods,
             .handler = struct {
                 fn action(s: *Context) void {
-                    s.document_handler.scroll(.Up);
+                    s.document_handler.scroll(.Up, 1.0);
+                    s.reload_page = true;
+                }
+            }.action,
+        },
+        .{
+            .codepoint = km.scroll_up_mult.codepoint,
+            .mods = km.scroll_up_mult.mods,
+            .handler = struct {
+                fn action(s: *Context) void {
+                    s.document_handler.scroll(.Up, s.config.general.scroll_mult);
                     s.reload_page = true;
                 }
             }.action,
@@ -102,7 +128,17 @@ pub fn handleKeyStroke(self: *Self, key: vaxis.Key, km: Config.KeyMap) !void {
             .mods = km.scroll_down.mods,
             .handler = struct {
                 fn action(s: *Context) void {
-                    s.document_handler.scroll(.Down);
+                    s.document_handler.scroll(.Down, 1.0);
+                    s.reload_page = true;
+                }
+            }.action,
+        },
+        .{
+            .codepoint = km.scroll_down_mult.codepoint,
+            .mods = km.scroll_down_mult.mods,
+            .handler = struct {
+                fn action(s: *Context) void {
+                    s.document_handler.scroll(.Down, s.config.general.scroll_mult);
                     s.reload_page = true;
                 }
             }.action,
@@ -112,7 +148,17 @@ pub fn handleKeyStroke(self: *Self, key: vaxis.Key, km: Config.KeyMap) !void {
             .mods = km.scroll_left.mods,
             .handler = struct {
                 fn action(s: *Context) void {
-                    s.document_handler.scroll(.Left);
+                    s.document_handler.scroll(.Left, 1.0);
+                    s.reload_page = true;
+                }
+            }.action,
+        },
+        .{
+            .codepoint = km.scroll_left_mult.codepoint,
+            .mods = km.scroll_left_mult.mods,
+            .handler = struct {
+                fn action(s: *Context) void {
+                    s.document_handler.scroll(.Left, s.config.general.scroll_mult);
                     s.reload_page = true;
                 }
             }.action,
@@ -122,7 +168,17 @@ pub fn handleKeyStroke(self: *Self, key: vaxis.Key, km: Config.KeyMap) !void {
             .mods = km.scroll_right.mods,
             .handler = struct {
                 fn action(s: *Context) void {
-                    s.document_handler.scroll(.Right);
+                    s.document_handler.scroll(.Right, 1.0);
+                    s.reload_page = true;
+                }
+            }.action,
+        },
+        .{
+            .codepoint = km.scroll_right_mult.codepoint,
+            .mods = km.scroll_right_mult.mods,
+            .handler = struct {
+                fn action(s: *Context) void {
+                    s.document_handler.scroll(.Right, s.config.general.scroll_mult);
                     s.reload_page = true;
                 }
             }.action,


### PR DESCRIPTION
This PR adds configurable multiplied zoom and scroll actions to accelerate document navigation in view mode. By default, holding `Shift` while zooming applies a 2× zoom-step multiplier, and holding `Shift` while scrolling applies a 10× scroll-step multiplier.

Also included (and perhaps more important) is a memory fix required to support additional keybindings.