### PR TITLE
feat: OSC 9;4 progress bar

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -72,7 +72,8 @@ Because fancy-cat provides sensible defaults, you only need to specify the optio
     "timeout": 5.0,
     "detect_dpi": true,
     "dpi": 96.0,
-    "history": 1000
+    "history": 1000,
+    "progress_bar": false
   },
   "StatusBar": {
     "enabled": true,
@@ -230,6 +231,7 @@ The `General` section includes various display and timing settings.
 | `retry_delay` | Float (seconds) | Delay before retrying to load a document or render a page |
 | `timeout` | Float (seconds) | Maximum time to keep retrying before giving up on loading a document or rendering a page |
 | `history` | Integer | Maximum number of entries in command history |
+| `progress_bar` | Boolean | Use graphical progress bar for reload indicator (requires a terminal with OSC 9;4 support) |
 
 >[!TIP]
 >The color replacement feature works by replacing white and black with custom colors, which also affects the full color range depending on contrast. By default, `white` is set to black (`#000000`) and `black` is set to white (`#ffffff`). For a seamless look, try setting `white` to match your terminal’s background color and `black` to match the foreground (text) color.

--- a/src/Context.zig
+++ b/src/Context.zig
@@ -158,13 +158,19 @@ pub const Context = struct {
                 w.setCallback(callback, &loop);
                 self.watcher_thread = try std.Thread.spawn(.{}, watcherWorker, .{ self, w });
                 self.current_reload_indicator_state = .watching;
-                if (self.config.status_bar.enabled and self.config.file_monitor.reload_indicator_duration > 0) {
-                    for (self.config.status_bar.items) |item| {
-                        if (item == .reload_aware) {
-                            try self.reload_indicator_timer.start(&loop);
-                            self.reload_indicator_active = true;
-                            break;
+                if (self.config.file_monitor.reload_indicator_duration > 0) {
+                    var need_reload_indicator = self.config.general.progress_bar;
+                    if (!need_reload_indicator and self.config.status_bar.enabled) {
+                        for (self.config.status_bar.items) |item| {
+                            if (item == .reload_aware) {
+                                need_reload_indicator = true;
+                                break;
+                            }
                         }
+                    }
+                    if (need_reload_indicator) {
+                        try self.reload_indicator_timer.start(&loop);
+                        self.reload_indicator_active = true;
                     }
                 }
             }
@@ -233,11 +239,13 @@ pub const Context = struct {
                 self.cache.clear();
                 self.reload_page = true;
                 if (self.reload_indicator_active) {
+                    if (self.config.general.progress_bar) try self.tty.writer().print("\x1b]9;4;1;100\x07", .{});
                     self.current_reload_indicator_state = .reload;
                     self.reload_indicator_timer.notifyChange();
                 }
             },
             .reload_done => {
+                if (self.config.general.progress_bar) try self.tty.writer().print("\x1b]9;4;0;0\x07", .{});
                 self.current_reload_indicator_state = .watching;
             },
         }

--- a/src/config/Config.zig
+++ b/src/config/Config.zig
@@ -101,6 +101,8 @@ pub const General = struct {
     dpi: f32 = 96.0,
     // whole number (possibly 0)
     history: u32 = 1000,
+    // terminal gui
+    progress_bar: bool = false,
 
     pub fn parse(val: std.json.Value, allocator: std.mem.Allocator) General {
         var general = General{};
@@ -134,6 +136,7 @@ pub const General = struct {
         general.detect_dpi = parseType(bool, val.object, "detect_dpi", allocator, general.detect_dpi);
         general.dpi = parseType(f32, val.object, "dpi", allocator, general.dpi);
         general.history = parseType(u32, val.object, "history", allocator, general.history);
+        general.progress_bar = parseType(bool, val.object, "progress_bar", allocator, general.progress_bar);
 
         return general;
     }


### PR DESCRIPTION
This small change adds an option to display a native terminal progress bar (a progress bar rendered directly by supported terminals using OSC 9;4) to indicate document reloads. The feature is disabled by default and can be enabled with the general option `"progress_bar": true`.